### PR TITLE
GIS conversion scripts (state plane to long-lat).

### DIFF
--- a/links.txt
+++ b/links.txt
@@ -1,0 +1,5 @@
+
+
+NCT COG maps and data: https://www.nctcog.org/regional-data/regional-data-center
+Frisco GIS data: https://www.friscotexas.gov/176/GIS-Data-Download
+

--- a/scripts/convert_POI.sh
+++ b/scripts/convert_POI.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+poi_list="Hike_Bike Historic_Sites Hotels Medical_Facilities Parks Public_Facilities Restaurants"
+
+INCOMING="2276"
+OUTGOING="4326"
+
+for layer in ${poi_list}
+do
+  shp2pgsql -s ${INCOMING}:${OUTGOING} -c ${layer}.shp > ${layer}.sql
+  cat ${layer}.sql | psql -U postgres -d test
+done

--- a/scripts/convert_boundaries.sh
+++ b/scripts/convert_boundaries.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+poi_list="City_ETJ Citylimits County_Line Proposed_Annexation"
+
+INCOMING="2276"
+OUTGOING="4326"
+
+for layer in ${poi_list}
+do
+  shp2pgsql -s ${INCOMING}:${OUTGOING} -c ${layer}.shp > ${layer}.sql
+  cat ${layer}.sql | psql -U postgres -d test
+done

--- a/scripts/pythonsnippet.py
+++ b/scripts/pythonsnippet.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+"""
+Sample code from _Tariq for converting from North Central Texas State Plane
+coordinates to WGS84 Long/Lat coordinates.
+
+"""
+
+
+from pyproj import Proj, transform
+
+inProj = Proj(init='epsg:2276')
+outProj = Proj(init='epsg:4326')
+
+x1,y1 = 4636565.411864,446097.654469
+x2,y2 = transform(inProj,outProj,x1,y1)
+
+print (x2,y2)


### PR DESCRIPTION
Cataloging two shell scripts for converting SHP files to PostGIS (but convertible to other formats too as needed).